### PR TITLE
Improved fix for non-zero exit codes of `tracer`.

### DIFF
--- a/dnf-automatic-restart
+++ b/dnf-automatic-restart
@@ -136,7 +136,7 @@ tracer_out="$(tracer || {
 printf 'tracer output:\n%s\n' "$tracer_out"
 
 daemon_reloaded=false
-tracer --services-only | tail --lines=+3 | sort | uniq | while read -r line; do
+(tracer --services-only || true) | tail --lines=+3 | sort | uniq | while read -r line; do
   if [[ "$daemon_reloaded" == 'false' ]]; then
     echo 'Reloading systemd daemon configuration'
     systemctl daemon-reload
@@ -155,7 +155,7 @@ tracer --services-only | tail --lines=+3 | sort | uniq | while read -r line; do
     echo 'Restarting docker because firewalld was restarted'
     systemctl restart docker
   fi
-done || true
+done
 
 # Kernel-only updates are not detected by tracer.
 # https://github.com/FrostyX/tracer/issues/45


### PR DESCRIPTION
Hello Alexander,

it had to happen. Once I finally submitted the pull request, I leaned back, relaxed - and saw a flaw in the fix or at least a chance to solve the problem better.
The ` ... || true` of my first fix encompasses the whole loop and may be a bit excessive. The new fix just covers the exit code of the `tracer`-call itself, so that failures in the loop still bring the bash script to a halt.
Sorry for the double PR.

Cheers,
Michael
