### PR TITLE
Allow reboot disallowed time period to span midnight

### DIFF
--- a/dnf-automatic-restart
+++ b/dnf-automatic-restart
@@ -54,7 +54,15 @@ trigger_reboot() {
   if [[ -n "$no_reboot_from" && -n "$no_reboot_to" ]]; then
     hour="$(date +%k)"
 
-    if ((hour >= no_reboot_from && hour <= no_reboot_to)); then
+    local no_reboot_now
+    if ((no_reboot_from > no_reboot_to)); then
+	no_reboot_now=$((hour <= no_reboot_from || hour >= no_reboot_to))
+    else
+	no_reboot_now=$((hour >= no_reboot_from && hour <= no_reboot_to))
+    fi
+    
+    
+    if ((no_reboot_now == 1)); then
       printf 'Rebooting the system is disallowed right now\n'
 
       if [[ -z "$reboot_at" ]]; then
@@ -181,9 +189,6 @@ while getopts ':dhn:r:' opt; do
           error 'No automatic reboot between hours must be numeric.'
         fi
 
-        if ((no_reboot_to < no_reboot_from)); then
-          error 'No automatic reboot between hours must be a valid "from-to" range.'
-        fi
         ;;
       r)
         reboot_at="$(printf %02d "$OPTARG")"


### PR DESCRIPTION
This pr allows users to specify, for example -n 8-2 to only allow reboots between 2am and 8am.

Remove check that no_reboot_to is less than no_reboot_from
If no_reboot_to is less than no_reboot_from, then check that curren
  hour is less than from or greater than to