### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Automatic reboots may be prevented or scheduled by specifying
    which also installs [tracer](http://tracer-package.com/).
 
    ```sh
-   dnf install --yes dnf-plugins-extras-tracer
+   dnf install -y dnf-plugins-extras-tracer
    ```
 
 1. Install `dnf-automatic` and enable it.
 
    ```sh
-   dnf install --yes dnf-automatic
+   dnf install -y dnf-automatic
    # Edit /etc/dnf/automatic.conf.
    systemctl enable dnf-automatic-install.timer
    ```


### PR DESCRIPTION
For "dnf install" the option for "assume yes" is either "-y" or "--assumeyes" as of at least Fedora 34.
dnf install -h   lists the options.
FWIW I could have sworn that "--yes" was a valid option at some point.